### PR TITLE
Render conference style todo item with colorful style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ dist/
 node_modules/
 publish/*.json
 publish/
+.idea
+.*~

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "joplin-plugin-todo",
+  "name": "joplin-plugin-inline-todo",
   "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "joplin-plugin-todo",
+      "name": "joplin-plugin-inline-todo",
       "version": "1.2.1",
       "license": "MIT",
       "devDependencies": {

--- a/plugin.config.json
+++ b/plugin.config.json
@@ -5,6 +5,9 @@
     "settings_tables.ts",
     "summaryFormatters/table.ts",
     "summaryFormatters/plain.ts",
-    "summary.ts"
+    "summary.ts",
+
+    "todoRender/index.ts",
+    "todoRender/conferenceStyleRender.ts"
   ]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import joplin from 'api';
-import { MenuItemLocation, SettingItemType } from 'api/types';
+import {ContentScriptType, MenuItemLocation, SettingItemType} from 'api/types';
 import { SummaryBuilder } from './builder';
 import { Note, Settings, Todo } from './types';
 import { update_summary } from './summary';
@@ -92,5 +92,11 @@ joplin.plugins.register({
 				update_summary(builder.summary, builder.settings, currentNote.id);
 			}
 		});
+
+		await joplin.contentScripts.register(
+			ContentScriptType.MarkdownItPlugin,
+			'conference_style_renderer',
+			'./todoRender/index.js'
+		);
 	},
 });

--- a/src/todoRender/conferenceStyleRender.ts
+++ b/src/todoRender/conferenceStyleRender.ts
@@ -11,6 +11,7 @@ export function conferenceStyleRender(markdownIt, _options) {
             const token = tokens[idx];
             let result = defaultRender(tokens, idx, options, env, self);
 
+            // todo: optimize the implementation. Or each string needs to be visited for 4x times
             let assignee = result.match(/@\S*/);
             if (assignee) {
                 result = result.replace(assignee[0], `[${assignee[0]}]`);

--- a/src/todoRender/conferenceStyleRender.ts
+++ b/src/todoRender/conferenceStyleRender.ts
@@ -6,30 +6,25 @@ export function conferenceStyleRender(markdownIt, _options) {
     markdownIt.renderer.rules.text = function (tokens, idx, options, env, self) {
         if (tokens.length >= 3 && tokens[0].type === "checkbox_wrapper_open"
             && tokens[tokens.length - 1].type === "checkbox_wrapper_close") {
-            console.log(markdownIt.renderer.rules);
-            console.log(tokens, idx);
-            const token = tokens[idx];
             let result = defaultRender(tokens, idx, options, env, self);
 
             // todo: optimize the implementation. Or each string needs to be visited for 4x times
             let assignee = result.match(/@\S*/);
             if (assignee) {
-                result = result.replace(assignee[0], `[${assignee[0]}]`);
+                result = result.replace(assignee[0], `<span class="inline-todo inline-todo-assignee">${assignee[0]}</span>`);
             }
 
-            let tags = result.match(/\+\S*/);
+            let tags = result.matchAll(/\+\S*/g);
             if (tags) {
                 for (let tag of tags) {
-                    result = result.replace(tag, `<${tag}>`);
+                    result = result.replace(tag, `<span class="inline-todo inline-todo-tag tag tag-right">${tag}</span>`);
                 }
             }
 
             let date = result.match(/\/\/\S*/);
             if (date) {
-                result = result.replace(date[0], `{${date[0]}}`);
+                result = result.replace(date[0], `<span class="inline-todo inline-todo-date">${date[0].substr(2)}</span>`);
             }
-
-            console.log(result);
 
             return result
         } else {

--- a/src/todoRender/conferenceStyleRender.ts
+++ b/src/todoRender/conferenceStyleRender.ts
@@ -1,0 +1,38 @@
+export function conferenceStyleRender(markdownIt, _options) {
+    const defaultRender = markdownIt.renderer.rules.text || function (tokens, idx, options, env, self) {
+        return self.renderToken(tokens, idx, options, env, self);
+    };
+
+    markdownIt.renderer.rules.text = function (tokens, idx, options, env, self) {
+        if (tokens.length >= 3 && tokens[0].type === "checkbox_wrapper_open"
+            && tokens[tokens.length - 1].type === "checkbox_wrapper_close") {
+            console.log(markdownIt.renderer.rules);
+            console.log(tokens, idx);
+            const token = tokens[idx];
+            let result = defaultRender(tokens, idx, options, env, self);
+
+            let assignee = result.match(/@\S*/);
+            if (assignee) {
+                result = result.replace(assignee[0], `[${assignee[0]}]`);
+            }
+
+            let tags = result.match(/\+\S*/);
+            if (tags) {
+                for (let tag of tags) {
+                    result = result.replace(tag, `<${tag}>`);
+                }
+            }
+
+            let date = result.match(/\/\/\S*/);
+            if (date) {
+                result = result.replace(date[0], `{${date[0]}}`);
+            }
+
+            console.log(result);
+
+            return result
+        } else {
+            return defaultRender(tokens, idx, options, env, self);
+        }
+    }
+}

--- a/src/todoRender/index.ts
+++ b/src/todoRender/index.ts
@@ -1,0 +1,16 @@
+import {conferenceStyleRender} from "./conferenceStyleRender";
+
+export default function (context) {
+    return {
+        plugin: function (markdownIt, _options) {
+            const pluginId = context.pluginId;
+
+            conferenceStyleRender(markdownIt, _options);
+        },
+        assets: function() {
+            return [
+                { name: 'todoRender.css' }
+            ];
+        },
+    }
+}

--- a/src/todoRender/todoRender.css
+++ b/src/todoRender/todoRender.css
@@ -1,0 +1,60 @@
+span.inline-todo {
+    font-size: 90%;
+    padding: 2px 3px;
+    text-align: center;
+}
+
+
+span.inline-todo-assignee {
+    background-color: dodgerblue;
+    color: white;
+    border-radius: 4px;
+}
+
+span.inline-todo-date {
+    background-color: orange;
+    color: white;
+    border-radius: 4px;
+}
+
+span.inline-todo-date::before {
+    content: '🕰 ';
+}
+
+.tag {
+    position: relative;
+    top: 0;
+    z-index: 1;
+    text-align: center;
+    color: white;
+}
+
+.tag::before,
+.tag::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    transform: skew(-12deg);
+}
+
+.tag::after {
+    right: 0;
+    bottom: 0;
+    z-index: -1;
+    border-radius: 5px;
+    background: red;
+}
+
+.tag-left::after {
+    left: 0;
+}
+
+.tag-left::before {
+    left: -10px;
+}
+
+.tag-right::after {
+    background: #52C41B;
+    left: 0;
+}
+


### PR DESCRIPTION
With this PR, the `@assignee`, `+tag`, `//date` can be rendered as a `span` with css.

For example, given: `- [ ] Joplin Plugin Development @Joplin +Development +Test //2022-05-05`

The rendered result: 
<img width="501" alt="image" src="https://user-images.githubusercontent.com/18042424/166884668-b47e4bbf-a81a-4073-bd60-679995211108.png">
