### PR TITLE
Mark TODO as done command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import joplin from 'api';
 import {ContentScriptType, MenuItemLocation, SettingItemType} from 'api/types';
 import { SummaryBuilder } from './builder';
 import { Note, Settings, Todo } from './types';
-import { update_summary } from './summary';
+import { update_summary, mark_current_line_as_done } from './summary';
 import { regexes, regexTitles, summaryTitles } from './settings_tables';
 import { create_summary_note } from './summary_note';
 
@@ -97,6 +97,21 @@ joplin.plugins.register({
 		);
 
 		const builder = new SummaryBuilder(await getSettings());
+
+		await joplin.commands.register({
+			name: "inlineTodo.markDone",
+			label: "Mark TODO as done",
+			execute: async () => {
+				mark_current_line_as_done(builder);
+			},
+		});
+
+		await joplin.views.menuItems.create(
+			"markDoneMenuTools",
+			"inlineTodo.markDone",
+			MenuItemLocation.EditorContextMenu,
+			{ accelerator: 'Ctrl+Alt+D' }
+		);
 
 		await joplin.settings.onChange(async (event) => {
 			builder.settings = await getSettings();

--- a/src/settings_tables.ts
+++ b/src/settings_tables.ts
@@ -1,6 +1,6 @@
 import { TitleEntry } from './types';
-import { plainBody } from './summaryFormatters/plain';
-import { tableBody } from './summaryFormatters/table';
+import { plainBody, formatTodo as plainFormat } from './summaryFormatters/plain';
+import { tableBody, formatTodo as tableFormat } from './summaryFormatters/table';
 
 
 // To add a new summary format, create a new file in src/summaryFormatters/
@@ -15,6 +15,15 @@ export const summaries = {
 	table: {
 		title: 'Table',
 		func: tableBody,
+	},
+}
+
+export const formats = {
+	plain: {
+		func: plainFormat,
+	},
+	table: {
+		func: tableFormat,
 	},
 }
 

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -1,6 +1,8 @@
 import joplin from 'api';
 import { Settings, Todo, Summary } from './types';
-import { summaries } from './settings_tables';
+import { summaries, regexes } from './settings_tables';
+import { plainBody } from './summaryFormatters/plain';
+import { SummaryBuilder } from './builder';
 
 export async function update_summary(summary_map: Summary, settings: Settings, summary_id: string, old_body: string) {
 	let bodyFunc = summaries[settings.summary_type].func;
@@ -29,4 +31,63 @@ async function setSummaryBody(summaryBody: string, summary_id: string, old_body:
 	if (settings.force_sync) {
 		await joplin.commands.execute('synchronize');
 	}
+}
+
+export async function mark_current_line_as_done(builder: SummaryBuilder) {
+	// try to find a corresponding TODO and set it as complete in its original note 
+	const line = await get_current_line();
+	const [originId, msg] = parse_summary_line(line);
+	if (originId == undefined) { return undefined; }
+
+	if (set_origin_todo(originId, msg)) {
+		// origin was updated, so update the TODO summary
+		const currentNote = await joplin.workspace.selectedNote();
+		await builder.search_in_all();
+		update_summary(builder.summary, builder.settings, currentNote.id, currentNote.body);
+	}
+}
+
+async function get_current_line(): Promise<string> {
+	const n = await joplin.commands.execute('editor.execCommand', {
+		name: 'getCursor',
+		args: ['head'],
+	});
+	return await joplin.commands.execute('editor.execCommand', {
+		name: 'getLine',
+		args: [n.line],
+	});
+}
+
+function parse_summary_line(line: string): string[] {
+	const origin = (new RegExp(/\[(?<title>[^\[]+)\]\(:\/(?<id>.*)\)/g)).exec(line);
+	if (origin == undefined) { return [undefined, undefined]; }
+
+	let parse = regexes.list.msg([line]);
+	parse = parse.split(origin.groups.id + '): ')[1];
+	return [origin.groups.id, parse];
+}
+
+async function set_origin_todo(originId: string, msg: string): Promise<boolean> {
+	const origin = await joplin.data.get(['notes', originId], { fields: ['body'] });
+	let lines = origin.body.split('\n');
+	const subMsg = msg.split(' ').slice(1, -1).join(' ');  // omitting date
+
+	let changed = false;
+	for (let i = 0; i < lines.length; i++) {
+		if (lines[i].includes(msg) || (lines[i].includes(subMsg))) {
+			console.log(lines[i]);
+			lines[i] = lines[i].replace('- [ ]', '- [x]');
+			lines[i] = lines[i].replace('[TODO]', '[DONE]');
+			console.log(lines[i]);
+			changed = true;
+			break;
+		}
+	}
+
+	if (changed) {
+		// edit origin note
+		await joplin.data.put(['notes', originId], null, { body: lines.join('\n') });
+	}
+
+	return changed
 }

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -70,11 +70,13 @@ function parse_summary_line(line: string): string[] {
 async function set_origin_todo(originId: string, msg: string): Promise<boolean> {
 	const origin = await joplin.data.get(['notes', originId], { fields: ['body'] });
 	let lines = origin.body.split('\n');
-	const subMsg = msg.split(' ').slice(1, -1).join(' ');  // omitting date
+	const words = msg.split(' ');
+	const date = words[0];  // search for (potentially) a date separately
+	const subMsg = words.slice(1, -1).join(' ');  // omitting date
 
 	let changed = false;
 	for (let i = 0; i < lines.length; i++) {
-		if (lines[i].includes(msg) || (lines[i].includes(subMsg))) {
+		if (lines[i].includes(subMsg) && (lines[i].includes(date))) {
 			console.log(lines[i]);
 			lines[i] = lines[i].replace('- [ ]', '- [x]');
 			lines[i] = lines[i].replace('[TODO]', '[DONE]');

--- a/src/summary.ts
+++ b/src/summary.ts
@@ -77,10 +77,8 @@ async function set_origin_todo(originId: string, msg: string): Promise<boolean> 
 	let changed = false;
 	for (let i = 0; i < lines.length; i++) {
 		if (lines[i].includes(subMsg) && (lines[i].includes(date))) {
-			console.log(lines[i]);
 			lines[i] = lines[i].replace('- [ ]', '- [x]');
 			lines[i] = lines[i].replace('[TODO]', '[DONE]');
-			console.log(lines[i]);
 			changed = true;
 			break;
 		}

--- a/src/summaryFormatters/plain.ts
+++ b/src/summaryFormatters/plain.ts
@@ -1,6 +1,6 @@
 import { Settings, Todo, Summary } from '../types';
 
-function formatTodo(todo: Todo): string {
+export function formatTodo(todo: Todo): string {
 	const tags = todo.tags.map((s: string) => '+' + s).join(' ');
 	if (todo.date) {
 		return `- [${todo.note_title}](:/${todo.note}): ${todo.date} ${todo.msg} ${tags}\n`;

--- a/src/summaryFormatters/table.ts
+++ b/src/summaryFormatters/table.ts
@@ -1,6 +1,6 @@
 import { Settings, Todo, Summary } from '../types';
 
-function formatTodo(todo: Todo): string {
+export function formatTodo(todo: Todo): string {
 	return `| ${todo.msg} | ${todo.assignee} | ${todo.date} | ${todo.tags.join(' ')} | ${todo.parent_title} | [${todo.note_title}](:/${todo.note}) |\n`;
 }
 


### PR DESCRIPTION
This PR adds a context menu command that will check the box (or change the link) in the original note of the selected task. Theoretically, this should also update the summary note, but currently summary note content is not refreshed successfully (I saw the related issue, and the workaround, but this doesn't seem to be effective on my Joplin client).

<img width="596" alt="image" src="https://user-images.githubusercontent.com/17462125/182575570-ca636897-7ecb-4ebe-8fd3-d2ab59a88bd4.png">
