### PR TITLE
Add ability to optionally sort table by date

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ async function getSettings(): Promise<Settings> {
 		scan_period_c: await joplin.settings.value('scanPeriodRequestCount'),
 		todo_type: regexes[await joplin.settings.value('regexType')],
 		summary_type: await joplin.settings.value('summaryType'),
+		sort_by: await joplin.settings.value('sortBy'),
 		force_sync: await joplin.settings.value('forceSync'),
 		show_complete_todo: await joplin.settings.value('showCompletetodoitems'),
 		auto_refresh_summary: await joplin.settings.value('autoRefreshSummary'),
@@ -46,6 +47,18 @@ joplin.plugins.register({
 				section: 'settings.calebjohn.todo',
 				public: true,
 				label: 'Choose a Summary Note Format. Check the project page for examples',
+			},
+			'sortBy': {
+				value: 'assignee',
+				type: SettingItemType.String,
+				isEnum: true,
+				options: {
+					'assignee': 'Assignee (Default)',
+					'date': 'Due Date'
+				},
+				section: 'settings.calebjohn.todo',
+				public: true,
+				label: 'Sort table display TODOs by',
 			},
 			'scanPeriod': {
 				value: 11,

--- a/src/summaryFormatters/table.ts
+++ b/src/summaryFormatters/table.ts
@@ -9,8 +9,33 @@ export function formatTodo(todo: Todo, settings: Settings): string {
 }
 
 // Create a string by concating some Note fields, this will determine sort order
-function sortString(todo: Todo): string {
+function sortString(todo: Todo, settings: Settings): string {
+	if (settings.sort_by === 'date') {
+		const sortableDate = formatDateForSorting(todo.date) || '9999-12-31';
+		return sortableDate + todo.assignee + todo.parent_title + todo.note_title + todo.msg + todo.note;
+	}
 	return todo.assignee + todo.parent_title + todo.note_title + todo.msg + todo.note;
+}
+
+// Convert date to sortable format (YYYY-MM-DD), handling various input formats
+function formatDateForSorting(dateStr: string): string | null {
+	if (!dateStr || dateStr.trim() === '') {
+		return null;
+	}
+	
+	try {
+		const date = new Date(dateStr);
+		if (isNaN(date.getTime())) {
+			return null;
+		}
+		
+		// Format as YYYY-MM-DD for proper string sorting
+		return date.getFullYear() + '-' + 
+			String(date.getMonth() + 1).padStart(2, '0') + '-' + 
+			String(date.getDate()).padStart(2, '0');
+	} catch {
+		return null;
+	}
 }
 
 export async function tableBody(summary_map: Summary, settings: Settings) {
@@ -29,7 +54,7 @@ export async function tableBody(summary_map: Summary, settings: Settings) {
 		todos = todos.concat(tds)
 	}
 
-	todos = todos.sort((a, b) => sortString(a).localeCompare(sortString(b), undefined, { sensitivity: 'accent', numeric: true }));
+	todos = todos.sort((a, b) => sortString(a, settings).localeCompare(sortString(b, settings), undefined, { sensitivity: 'accent', numeric: true }));
 	for (let todo of todos) {
 		if (todo.completed) {
 			completed.push(todo)

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,6 +44,7 @@ export interface Settings {
 	scan_period_c: number;
 	todo_type: RegexEntry;
 	summary_type: string;
+	sort_by: string;
 	force_sync: boolean;
 	show_complete_todo: boolean;
 	auto_refresh_summary: boolean;


### PR DESCRIPTION
Feel free to reject if this doesn't align with your goals:



- Adds functionality to be able to sort the table display by due date.
- If selected and no dates are added, sort order is unchanged being Date -> existing sort logic (assignee)
- When date sorting is selected, todos are sorted chronologically with undated items appearing last. Logic here being that users will want to complete TODOs in chronological order, so no reverse sort default needed
- Adds a "Sort table display TODOs by" setting with options for current behavior: "Assignee (Default)" and "Due Date".